### PR TITLE
Support for uploading files

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,9 @@
   },
   "dependencies": {
     "coffee-script": "~1.9.0",
-    "ws": "0.4.31",
-    "log": "1.4.0"
+    "form-data": "^0.2.0",
+    "log": "1.4.0",
+    "ws": "0.4.31"
   },
   "devDependencies": {
     "grunt": "^0.4.5",

--- a/src/comment.coffee
+++ b/src/comment.coffee
@@ -1,0 +1,32 @@
+Channel = require './channel'
+
+class Comment extends Channel
+  constructor: (@_file, data = {}) ->
+    super @_file._client, data
+
+  edit: (text, callback)->
+    params = {
+      "id": @id
+      "file": @_file.id
+      "comment": text
+    }
+    @_client._apiCall 'files.comments.edit', params, =>
+      @_onEditComment arguments...
+      callback? arguments...
+
+  _onEdit: (data)=>
+    @_client.logger.debug data
+
+  delete: (callback) ->
+    params = {
+      "id": @id
+      "file": @_file.id
+    }
+    @_client._apiCall 'files.comments.delete', params, =>
+      @_onDeleteComment arguments...
+      callback? arguments...
+
+  _onDelete: (data)=>
+    @_client.logger.debug data
+
+module.exports = Comment

--- a/src/file.coffee
+++ b/src/file.coffee
@@ -1,0 +1,105 @@
+Channel = require './channel'
+Comment = require './comment'
+
+class File extends Channel
+  constructor: (@_client, data = {}) ->
+    super @_client, data
+
+    @comments = {}
+    @_fetchedComments = false
+
+    if @comments_count > 0
+      @setComments()
+    else
+      @_fetchedComments = true
+
+  setComments: (callback) ->
+    params = {
+      "file": @id
+    }
+    @_client._apiCall 'files.info', params, =>
+      @_onSetComments arguments...
+      callback? arguments...
+
+  _onSetComments: (data) =>
+    @_client.logger.debug data
+
+    @_fetchedComments = true
+    for k of data.comments
+      c = data.comments[k]
+      @comments[c.id] = @newComment c
+
+    @_client.emit 'fetchCommentsOn' + @id, data.comments
+
+  newComment: (comment) ->
+    return new Comment @, comment
+
+  getComments: ->
+    if @_fetchedComments
+      @comments
+    else
+      null
+
+  edit: (params, callback) ->
+    params.file = @id
+    @_client._apiCall 'files.edit', params, =>
+      @_onEdit arguments...
+      callback? arguments...
+
+  _onEdit: (data) =>
+    @_client.logger.debug data
+
+  delete: (callback) ->
+    params = {
+      "file": @id
+    }
+    @_client._apiCall 'files.delete', params, =>
+      @_onDelete arguments...
+      callback? arguments...
+
+  _onDelete: (data) =>
+    @_client.logger.debug data
+
+
+  addComment: (text, callback) ->
+    params = {
+      "file": @id,
+      "comment": text
+    }
+    @_client._apiCall 'files.comments.add', params, =>
+      @_onAddComment arguments...
+      callback arguments...
+
+  _onAddComment: (data)=>
+    @_client.logger.debug data
+
+  # TODO Not Supported yet
+
+  # share: (text)->
+  #   params = {
+  #     "file": @id
+  #   }
+  #   @_client._apiCall 'files.share', params, @_onShare
+
+  # _onShare: (data)=>
+  #   @_client.logger.debug data
+
+  # unshared: (text)->
+  #   params = {
+  #     "file": @id
+  #   }
+  #   @_client._apiCall 'files.unshared', params, @_onUnshared
+
+  # _onUnshared: (data)=>
+  #   @_client.logger.debug data
+
+  # public: (text)->
+  #   params = {
+  #     "file": @id
+  #   }
+  #   @_client._apiCall 'files.public', params, @_onPublic
+
+  # _onPublic: (data)=>
+  #   @_client.logger.debug data
+
+module.exports = File


### PR DESCRIPTION
I rebased https://github.com/slackhq/node-slack-client/pull/22 on master and fixed up a few of the issues mentioned in that PR.

Also of note is that file uploading is now done with a multipart request. I'm allowing the caller to override the `token` param, which is [essential for performing a file upload from a bot](https://twitter.com/alexkwolfe/status/619176068600041472). Bots cannot do file uploads so a real user's API token must be provided.

```coffeescript
# Here's what a createFile call looks like
client.createFile file: '/home/user/smiley.png', token: 'xxxx-xxxxxxxx-xxxxxxxx', channels:'panic room', (result) ->
  console.log(result)
```

I'm looking for feedback on this PR and am happy to make adjustments, etc.