### PR TITLE
Allows for custom tokens in place of the bot's

### DIFF
--- a/src/client.coffee
+++ b/src/client.coffee
@@ -537,7 +537,7 @@ class Client extends EventEmitter
       return message
 
   _apiCall: (method, params, callback) ->
-    params['token'] = @token
+    if typeof params.token != "string" then params['token'] = @token
 
     post_data = querystring.stringify(params)
 


### PR DESCRIPTION
This is useful in methods such as "chat.delete" where the user may require a token with administrative access.