### PR TITLE
Handle reconnecting when a team migration was started or is in progress

### DIFF
--- a/src/client.coffee
+++ b/src/client.coffee
@@ -488,10 +488,18 @@ class Client extends EventEmitter
 
       when 'star_added'
           @emit 'star_added', message
-      
+
       when 'star_removed'
           @emit 'star_removed', message
 
+      # when team_migration_started happens, reconnect so it can get the new thing
+      when 'team_migration_started'
+        @logger.info "Team migration started, prepare for reconnect"
+        @reconnect()
+      # if it's still in progress, it's not ready yet, so try again
+      when 'migration_in_progress'
+        @logger.info "Team migration still in progress, prepare for reconnect"
+        @reconnect()
       else
         if message.reply_to
           if message.type == 'pong'


### PR DESCRIPTION
This is to address https://github.com/slackhq/node-slack-client/issues/180 . I spoke a little bit about the problem and fix: https://github.com/slackhq/hubot-slack/issues/203#issuecomment-198142935

> I had contacted Slack about debugging this by triggering a bunch of  migrations on a test account and test bot, and @ofross was kind enough to sit with me while I debugged and he hit a button to cause the migration. I was able to reproduce it consistently easily enough, and the hard part was finding where to detect the upcoming migration. I had a workaround by changing hubot-slack, but I was worried the conditional I added it under was being used for reconnect when the ping was too old, and would cause double pings. That lead me to adding explicitly handling the migration events.

> I'm _pretty_ sure you can install a version of node-slack-client in your hubot, and it will use that version rather than what hubot-slack specifies:
 
>    npm install --save "technicalpickles/node-slack-client#reconnect-on-migration-1.4x"

>It's a little complicated to release this, because master has the 2.x series, and there's a lot of changes without a 1.4.x branch I can work against. I filed https://github.com/slackhq/node-slack-client/issues/180 to figure that out.

> I still need to find a way to recreate the 'ping too old' condition to make sure that is fixed too. I am trying to figure out how to use toxiproxy to do it.

One concern I have is that while this would fix other projects using node-slack-client, if they already add their own reconnect logic, this could cause double connects, and thus receiving two of everything. I actually ran into that at one point while debugging.

cc https://github.com/slackhq/node-slack-client/issues/180 for when the 1.x branch was created for releasing this