### PR TITLE
update DmFacet to use updated makeAPIcall args

### DIFF
--- a/lib/clients/web/facets/dm.js
+++ b/lib/clients/web/facets/dm.js
@@ -24,11 +24,11 @@ function DmFacet(makeAPICall) {
  * @param {function} optCb Optional callback, if not using promises.
  */
 DmFacet.prototype.close = function close(channel, optCb) {
-  var args = {
+  var requiredArgs = {
     channel: channel
   };
 
-  return this.makeAPICall('im.close', args, optCb);
+  return this.makeAPICall('im.close', requiredArgs, null, optCb);
 };
 
 /**
@@ -44,12 +44,11 @@ DmFacet.prototype.close = function close(channel, optCb) {
  * @param {function} optCb Optional callback, if not using promises.
  */
 DmFacet.prototype.history = function history(channel, opts, optCb) {
-  var args = {
-    channel: channel,
-    opts: opts
+  var requiredArgs = {
+    channel: channel
   };
 
-  return this.makeAPICall('im.history', args, optCb);
+  return this.makeAPICall('im.history', requiredArgs, opts, optCb);
 };
 
 /**
@@ -58,9 +57,9 @@ DmFacet.prototype.history = function history(channel, opts, optCb) {
  * @param {function} optCb Optional callback, if not using promises.
  */
 DmFacet.prototype.list = function list(optCb) {
-  var args = {};
+  var requiredArgs = {};
 
-  return this.makeAPICall('im.list', args, optCb);
+  return this.makeAPICall('im.list', requiredArgs, null, optCb);
 };
 
 /**
@@ -72,12 +71,12 @@ DmFacet.prototype.list = function list(optCb) {
  * @param {function} optCb Optional callback, if not using promises.
  */
 DmFacet.prototype.mark = function mark(channel, ts, optCb) {
-  var args = {
+  var requiredArgs = {
     channel: channel,
     ts: ts
   };
 
-  return this.makeAPICall('im.mark', args, optCb);
+  return this.makeAPICall('im.mark', requiredArgs, null, optCb);
 };
 
 /**
@@ -88,11 +87,11 @@ DmFacet.prototype.mark = function mark(channel, ts, optCb) {
  * @param {function} optCb Optional callback, if not using promises.
  */
 DmFacet.prototype.open = function open(user, optCb) {
-  var args = {
+  var requiredArgs = {
     user: user
   };
 
-  return this.makeAPICall('im.open', args, optCb);
+  return this.makeAPICall('im.open', requiredArgs, null, optCb);
 };
 
 


### PR DESCRIPTION
For calls in `DmFacet` like `dm.open` the callback is never being called.

```javascript
SlackClient = require '@slack/client'

slack = new SlackClient.WebClient("mytoken")
slack.dm.open('USERID', function(err, response) {
  console.log('this will never be logged');
});
```

The equivalent call with `im.open` works.

Update `DmFacet` to use the updated `makeAPICall` signature from https://github.com/slackhq/node-slack-client/pull/195 with separated `requiredArgs` and `opts`.
