### PR TITLE
Fix retry-after header name and add fallback value

### DIFF
--- a/lib/clients/transports/call-transport.js
+++ b/lib/clients/transports/call-transport.js
@@ -35,8 +35,10 @@ var handleTransportError = function handleTransportError(err, retryOp, apiCb) {
  */
 var handleRateLimitResponse = function handleRateLimitResponse(retryArgs, headers) {
   var client = retryArgs.client;
-  var headerSecs = parseInt(headers['Retry-After'], 10);
+  var retryAfter = parseInt(headers['retry-after'], 10);
+  var headerSecs = Number.isInteger(retryAfter) ? retryAfter : 60;
   var headerMs = headerSecs * 1000;
+  client.logger('info', 'Rate limited, will retry %s seconds', headerSecs);
 
   client.requestQueue.pause();
 

--- a/test/clients/web/client.js
+++ b/test/clients/web/client.js
@@ -102,7 +102,7 @@ describe('Web API Client', function () {
     it('should pause job execution in response to a 429 header', function (done) {
       nock('https://slack.com/api')
         .post('/test')
-        .reply(429, '{}', { 'X-Retry-After': 0 });
+        .reply(429, '{}', { 'retry-after': 0 });
 
       attemptAPICall(done);
     });


### PR DESCRIPTION
When diagnosing an unrelated issue I noticed that our in-house bot was repeatedly trying requests after receiving a 429 response.

This was caused by the header ```Retry-After``` being instead ```retry-after``` and the previous code then passing NaN to setTimeout which caused it to be called immediately.

I fixed it by renaming the header and then adding a fallback value if the header is not present. I also added a log message so that it is more obvious what is happening.