### PR TITLE
Fix and improve consistency of datastore examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,11 +123,7 @@ var rtm = new RtmClient(token, {
   // Sets the level of logging we require
   logLevel: 'error',
   // Initialise a data store for our client, this will load additional helper functions for the storing and retrieval of data
-  dataStore: new MemoryDataStore(),
-  // Boolean indicating whether Slack should automatically reconnect after an error response
-  autoReconnect: true,
-  // Boolean indicating whether each message should be marked as read or not after it is processed
-  autoMark: true
+  dataStore: new MemoryDataStore()
 });
 
 rtm.start();

--- a/examples/example-rtm-client-datastore.js
+++ b/examples/example-rtm-client-datastore.js
@@ -7,8 +7,8 @@ var MemoryDataStore = require('@slack/client').MemoryDataStore;
 var token = process.env.SLACK_API_TOKEN || '';
 
 var rtm = new RtmClient(token, {
-  logLevel: 'info', // check this out for more on logger: https://github.com/winstonjs/winston
-  dataStore: new MemoryDataStore({}) // pass a new MemoryDataStore instance to cache information
+  logLevel: 'error', // check this out for more on logger: https://github.com/winstonjs/winston
+  dataStore: new MemoryDataStore() // pass a new MemoryDataStore instance to cache information
 });
 
 rtm.start();


### PR DESCRIPTION
Remove the `autoMark` option from the Data stores section of README.md since it no longer seems to be a valid option. Likewise, remove the `autoReconnect: true` option since it defaults to true. The user can learn about the available options from the source code where they are documented.

Improve consistency between example-rtm-client-datastore.js and README.md.