### PR TITLE
getModelClass requires an obj to be passed in to check the id

### DIFF
--- a/lib/models/model.js
+++ b/lib/models/model.js
@@ -108,7 +108,7 @@ Model.prototype._setObjectProperty = function _setObjectProperty(key, val) {
     if (hasProperty) {
       this[key].update(val);
     } else {
-      ModelClass = helpers.getModelClass();
+      ModelClass = helpers.getModelClass(val);
       this[key] = new ModelClass(val);
     }
     this._properties[key] = PROPERTY_TYPES.MODEL;
@@ -136,7 +136,7 @@ Model.prototype._setArrayProperty = function _setArrayProperty(key, val) {
     // Assumes that all values in the array are of the same type
     firstItem = val[0];
     if (helpers.isModelObj(firstItem)) {
-      ModelClass = helpers.getModelClass();
+      ModelClass = helpers.getModelClass(firstItem);
       this[key] = map(val, function makeChildModelObjs(item) {
         return new ModelClass(item);
       });


### PR DESCRIPTION
* [X] I've read and understood the [Contributing guidelines](./CONTRIBUTING.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
* [X] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [X] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [X] I've written tests to cover the new code and functionality included in this PR.
* [X] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
When fields in a Slack API response from the RTM API return fields with objects and those objects contain a key called id, and the value of that field starts with U, e.g. USLACKBOT, the client crashes:

```
error:  TypeError: Cannot read property 'id' of undefined
    at Object.getModelClass (/Users/bert/code/slack-hodorbot/node_modules/@slack/client/lib/models/helpers.js:26:26)
    at User._setObjectProperty (/Users/bert/code/slack-hodorbot/node_modules/@slack/client/lib/models/model.js:111:28)
    at User._setModelProperty (/Users/bert/code/slack-hodorbot/node_modules/@slack/client/lib/models/model.js:82:10)
    at wrapper (/Users/bert/code/slack-hodorbot/node_modules/lodash/lodash.js:4597:19)
    at /Users/bert/code/slack-hodorbot/node_modules/lodash/lodash.js:4573:15
    at baseForOwn (/Users/bert/code/slack-hodorbot/node_modules/lodash/lodash.js:2728:24)
    at /Users/bert/code/slack-hodorbot/node_modules/lodash/lodash.js:4542:18
    at forEach (/Users/bert/code/slack-hodorbot/node_modules/lodash/lodash.js:8847:14)
    at User.setProperties [as _setProperties] (/Users/bert/code/slack-hodorbot/node_modules/@slack/client/lib/models/model.js:58:3)
    at User.Model (/Users/bert/code/slack-hodorbot/node_modules/@slack/client/lib/models/model.js:33:8)
    at new User (/Users/bert/code/slack-hodorbot/node_modules/@slack/client/lib/models/user.js:11:9)
    at SlackMemoryDataStore.cacheRtmUser (/Users/bert/code/slack-hodorbot/node_modules/@slack/client/lib/data-store/data-store.js:391:18)
    at wrapper (/Users/bert/code/slack-hodorbot/node_modules/lodash/lodash.js:4597:19)
    at arrayEach (/Users/bert/code/slack-hodorbot/node_modules/lodash/lodash.js:485:11)
    at forEach (/Users/bert/code/slack-hodorbot/node_modules/lodash/lodash.js:8847:14)
    at SlackMemoryDataStore.cacheRtmStart (/Users/bert/code/slack-hodorbot/node_modules/@slack/client/lib/data-store/data-store.js:390:3)
```

This is because the helper function `getModelClass` requires an obj passed to it. This passes the object that is the value of that field to it.

#### Test strategy
It no longer crashes.
